### PR TITLE
handleResponderGrant should account for existing offset

### DIFF
--- a/lib/PanController.js
+++ b/lib/PanController.js
@@ -282,7 +282,7 @@ var PanController = React.createClass({
         break;
       case "snap":
       case "decay":
-        anim.setOffset(anim._value);
+        anim.setOffset(anim._value + anim._offset);
         anim.setValue(0);
         break;
     }


### PR DESCRIPTION
Fixes an issue where `onPanResponderGrant` would not take existing offset into account.
